### PR TITLE
feat!: glob-based includes/excludes config

### DIFF
--- a/README.ru.md
+++ b/README.ru.md
@@ -230,14 +230,13 @@ console.log(output);
 
 Файл `ftaql.json` управляет поведением анализа. Например, в нём можно настроить:
 
-- `extensions`
-- `exclude_filenames`
-- `exclude_directories`
+- `includes` — glob-паттерны для включения файлов
+- `excludes` — glob-паттерны для исключения файлов
 - `score_cap`
 - `include_comments`
 - `exclude_under`
 
-При анализе проекта FtaQl также учитывает `.gitignore`. Поэтому `node_modules` обычно пропускается автоматически, если уже игнорируется git-правилами. Если каталог не покрыт `.gitignore`, добавьте его в `exclude_directories`. Подробности см. в [`docs/configuration/ru.md`](https://github.com/pikulev/ftaql/blob/main/docs/configuration/ru.md).
+При анализе проекта FtaQl также учитывает `.gitignore`. Поэтому `node_modules` обычно пропускается автоматически, если уже игнорируется git-правилами. Если каталог не покрыт `.gitignore`, добавьте его в `excludes`. Подробности см. в [`docs/configuration/ru.md`](https://github.com/pikulev/ftaql/blob/main/docs/configuration/ru.md).
 
 При разрешении импортов FtaQl также автоматически обнаруживает `tsconfig.json` и `jsconfig.json`. Поддерживаются:
 

--- a/crates/ftaql/src/config/mod.rs
+++ b/crates/ftaql/src/config/mod.rs
@@ -21,13 +21,8 @@ impl From<FtaQlConfigOptional> for FtaQlConfigResolved {
     fn from(opt_config: FtaQlConfigOptional) -> Self {
         let default_config = get_default_config();
         FtaQlConfigResolved {
-            extensions: opt_config.extensions.unwrap_or(default_config.extensions),
-            exclude_filenames: opt_config
-                .exclude_filenames
-                .unwrap_or(default_config.exclude_filenames),
-            exclude_directories: opt_config
-                .exclude_directories
-                .unwrap_or(default_config.exclude_directories),
+            includes: opt_config.includes.unwrap_or(default_config.includes),
+            excludes: opt_config.excludes.unwrap_or(default_config.excludes),
             score_cap: opt_config.score_cap.unwrap_or(default_config.score_cap),
             include_comments: opt_config
                 .include_comments
@@ -40,29 +35,25 @@ impl From<FtaQlConfigOptional> for FtaQlConfigResolved {
 }
 
 pub fn get_default_config() -> FtaQlConfigResolved {
-    let default_config = FtaQlConfigResolved {
-        extensions: vec![
-            ".js".to_string(),
-            ".jsx".to_string(),
-            ".ts".to_string(),
-            ".tsx".to_string(),
+    FtaQlConfigResolved {
+        includes: vec![
+            "**/*.js".to_string(),
+            "**/*.jsx".to_string(),
+            "**/*.ts".to_string(),
+            "**/*.tsx".to_string(),
         ],
-        exclude_filenames: vec![
-            ".d.ts".to_string(),
-            ".min.js".to_string(),
-            ".bundle.js".to_string(),
-        ],
-        exclude_directories: vec![
-            "/dist".to_string(),
-            "/bin".to_string(),
-            "/build".to_string(),
+        excludes: vec![
+            "**/*.d.ts".to_string(),
+            "**/*.min.js".to_string(),
+            "**/*.bundle.js".to_string(),
+            "dist/**".to_string(),
+            "bin/**".to_string(),
+            "build/**".to_string(),
         ],
         score_cap: 1000,
         include_comments: false,
         exclude_under: 6,
-    };
-
-    default_config
+    }
 }
 
 pub fn read_config(
@@ -77,30 +68,10 @@ pub fn read_config(
         let provided_config: FtaQlConfigOptional =
             serde_json::from_str(&content).unwrap_or_default();
 
-        // For extensions, filenames and exclude_directories,
-        // user-provided values are added to the defaults.
+        // User-provided includes/excludes replace defaults entirely.
         return Result::Ok(FtaQlConfigResolved {
-            extensions: {
-                let mut extensions = default_config.extensions;
-                if let Some(mut provided) = provided_config.extensions {
-                    extensions.append(&mut provided);
-                }
-                extensions
-            },
-            exclude_filenames: {
-                let mut exclude_filenames = default_config.exclude_filenames;
-                if let Some(mut provided) = provided_config.exclude_filenames {
-                    exclude_filenames.append(&mut provided);
-                }
-                exclude_filenames
-            },
-            exclude_directories: {
-                let mut exclude_directories = default_config.exclude_directories;
-                if let Some(mut provided) = provided_config.exclude_directories {
-                    exclude_directories.append(&mut provided);
-                }
-                exclude_directories
-            },
+            includes: provided_config.includes.unwrap_or(default_config.includes),
+            excludes: provided_config.excludes.unwrap_or(default_config.excludes),
             score_cap: provided_config
                 .score_cap
                 .unwrap_or(default_config.score_cap),

--- a/crates/ftaql/src/config/tests.rs
+++ b/crates/ftaql/src/config/tests.rs
@@ -14,9 +14,8 @@ mod tests {
     fn test_read_config_with_valid_json() {
         let valid_json = r#"
     {
-        "extensions": [".foo.ts"],
-        "exclude_filenames": [".bar.ts"],
-        "exclude_directories": ["/baz"],
+        "includes": ["**/*.foo.ts"],
+        "excludes": ["**/*.bar.ts", "baz/**"],
         "exclude_under": 10,
         "score_cap": 500,
         "include_comments": true
@@ -27,33 +26,10 @@ mod tests {
         let path = temp_file.path().to_str().unwrap();
         let config = read_config(path.to_string(), false).unwrap();
 
+        assert_eq!(config.includes, vec!["**/*.foo.ts".to_string()]);
         assert_eq!(
-            config.extensions,
-            vec![
-                ".js".to_string(),
-                ".jsx".to_string(),
-                ".ts".to_string(),
-                ".tsx".to_string(),
-                ".foo.ts".to_string()
-            ]
-        );
-        assert_eq!(
-            config.exclude_filenames,
-            vec![
-                ".d.ts".to_string(),
-                ".min.js".to_string(),
-                ".bundle.js".to_string(),
-                ".bar.ts".to_string()
-            ]
-        );
-        assert_eq!(
-            config.exclude_directories,
-            vec![
-                "/dist".to_string(),
-                "/bin".to_string(),
-                "/build".to_string(),
-                "/baz".to_string(),
-            ]
+            config.excludes,
+            vec!["**/*.bar.ts".to_string(), "baz/**".to_string()]
         );
         assert_eq!(config.score_cap, 500);
         assert_eq!(config.include_comments, true);
@@ -63,8 +39,7 @@ mod tests {
     fn test_read_config_with_partial_json() {
         let partial_json = r#"
     {
-        "extensions": [".foo.ts"],
-        "exclude_filenames": [".bar.ts"]
+        "includes": ["**/*.foo.ts"]
     }
     "#;
 
@@ -72,31 +47,16 @@ mod tests {
         let path = temp_file.path().to_str().unwrap();
         let config = read_config(path.to_string(), false).unwrap();
 
+        assert_eq!(config.includes, vec!["**/*.foo.ts".to_string()]);
         assert_eq!(
-            config.extensions,
+            config.excludes,
             vec![
-                ".js".to_string(),
-                ".jsx".to_string(),
-                ".ts".to_string(),
-                ".tsx".to_string(),
-                ".foo.ts".to_string()
-            ]
-        );
-        assert_eq!(
-            config.exclude_filenames,
-            vec![
-                ".d.ts".to_string(),
-                ".min.js".to_string(),
-                ".bundle.js".to_string(),
-                ".bar.ts".to_string()
-            ]
-        );
-        assert_eq!(
-            config.exclude_directories,
-            vec![
-                "/dist".to_string(),
-                "/bin".to_string(),
-                "/build".to_string(),
+                "**/*.d.ts".to_string(),
+                "**/*.min.js".to_string(),
+                "**/*.bundle.js".to_string(),
+                "dist/**".to_string(),
+                "bin/**".to_string(),
+                "build/**".to_string(),
             ]
         );
         assert_eq!(config.score_cap, 1000);
@@ -110,28 +70,23 @@ mod tests {
         let config = read_config(nonexistent_path.to_string(), false).unwrap();
 
         assert_eq!(
-            config.extensions,
+            config.includes,
             vec![
-                ".js".to_string(),
-                ".jsx".to_string(),
-                ".ts".to_string(),
-                ".tsx".to_string(),
+                "**/*.js".to_string(),
+                "**/*.jsx".to_string(),
+                "**/*.ts".to_string(),
+                "**/*.tsx".to_string(),
             ]
         );
         assert_eq!(
-            config.exclude_filenames,
+            config.excludes,
             vec![
-                ".d.ts".to_string(),
-                ".min.js".to_string(),
-                ".bundle.js".to_string(),
-            ]
-        );
-        assert_eq!(
-            config.exclude_directories,
-            vec![
-                "/dist".to_string(),
-                "/bin".to_string(),
-                "/build".to_string(),
+                "**/*.d.ts".to_string(),
+                "**/*.min.js".to_string(),
+                "**/*.bundle.js".to_string(),
+                "dist/**".to_string(),
+                "bin/**".to_string(),
+                "build/**".to_string(),
             ]
         );
         assert_eq!(config.score_cap, 1000);
@@ -142,9 +97,8 @@ mod tests {
     fn test_read_config_with_user_specified_file_path() {
         let valid_json = r#"
     {
-        "extensions": [".foo.ts"],
-        "exclude_filenames": [".bar.ts"],
-        "exclude_directories": ["/baz"],
+        "includes": ["**/*.foo.ts"],
+        "excludes": ["**/*.bar.ts", "baz/**"],
         "score_cap": 500
     }
     "#;
@@ -154,33 +108,10 @@ mod tests {
 
         let config = read_config(path.to_string(), true).unwrap();
 
+        assert_eq!(config.includes, vec!["**/*.foo.ts".to_string()]);
         assert_eq!(
-            config.extensions,
-            vec![
-                ".js".to_string(),
-                ".jsx".to_string(),
-                ".ts".to_string(),
-                ".tsx".to_string(),
-                ".foo.ts".to_string(),
-            ]
-        );
-        assert_eq!(
-            config.exclude_filenames,
-            vec![
-                ".d.ts".to_string(),
-                ".min.js".to_string(),
-                ".bundle.js".to_string(),
-                ".bar.ts".to_string(),
-            ]
-        );
-        assert_eq!(
-            config.exclude_directories,
-            vec![
-                "/dist".to_string(),
-                "/bin".to_string(),
-                "/build".to_string(),
-                "/baz".to_string(),
-            ]
+            config.excludes,
+            vec!["**/*.bar.ts".to_string(), "baz/**".to_string()]
         );
         assert_eq!(config.score_cap, 500);
         assert_eq!(config.include_comments, false);

--- a/crates/ftaql/src/lib.rs
+++ b/crates/ftaql/src/lib.rs
@@ -41,19 +41,11 @@ pub fn analyze_project(path: &String, config: Option<FtaQlConfigResolved>) -> Ft
 
     // First pass: collect all imports
     let mut override_builder = ignore::overrides::OverrideBuilder::new(&repo_path);
-    for excl_dir in &fta_config.exclude_directories {
-        // Преобразуем в паттерн для исключения директории
-        let pat = format!(
-            "!{}{}",
-            excl_dir.trim_end_matches('/'),
-            if excl_dir.ends_with('/') { "**" } else { "/**" }
-        );
-        override_builder.add(&pat).unwrap();
+    for inc in &fta_config.includes {
+        override_builder.add(inc).unwrap();
     }
-    for excl_file in &fta_config.exclude_filenames {
-        // Преобразуем в паттерн для исключения файла по имени
-        let pat = format!("!**/{}", excl_file);
-        override_builder.add(&pat).unwrap();
+    for exc in &fta_config.excludes {
+        override_builder.add(&format!("!{}", exc)).unwrap();
     }
     let overrides = override_builder.build().unwrap();
     let mut walk_builder_base = ignore::WalkBuilder::new(&repo_path);

--- a/crates/ftaql/src/sqlite.rs
+++ b/crates/ftaql/src/sqlite.rs
@@ -718,9 +718,8 @@ mod tests {
 
     fn sample_config() -> FtaQlConfigResolved {
         FtaQlConfigResolved {
-            extensions: vec![".ts".to_string()],
-            exclude_filenames: vec![],
-            exclude_directories: vec![],
+            includes: vec!["**/*.ts".to_string()],
+            excludes: vec![],
             score_cap: 1000,
             include_comments: false,
             exclude_under: 0,

--- a/crates/ftaql/src/structs/mod.rs
+++ b/crates/ftaql/src/structs/mod.rs
@@ -26,9 +26,8 @@ mod serde_helpers {
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct FtaQlConfigOptional {
-    pub extensions: Option<Vec<String>>,
-    pub exclude_filenames: Option<Vec<String>>,
-    pub exclude_directories: Option<Vec<String>>,
+    pub includes: Option<Vec<String>>,
+    pub excludes: Option<Vec<String>>,
     pub score_cap: Option<usize>,
     pub include_comments: Option<bool>,
     pub exclude_under: Option<usize>,
@@ -63,9 +62,8 @@ pub struct ExportInfo {
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct FtaQlConfigResolved {
-    pub extensions: Vec<String>,
-    pub exclude_filenames: Vec<String>,
-    pub exclude_directories: Vec<String>,
+    pub includes: Vec<String>,
+    pub excludes: Vec<String>,
     pub score_cap: usize,
     pub include_comments: bool,
     pub exclude_under: usize,

--- a/crates/ftaql/src/utils/mod.rs
+++ b/crates/ftaql/src/utils/mod.rs
@@ -9,14 +9,8 @@ use std::path::Path;
 // Удаляю все вызовы is_excluded_filename (функция удалена)
 
 #[cfg(feature = "project-analysis")]
-pub fn is_valid_file(repo_path: &String, entry: &DirEntry, config: &FtaQlConfigResolved) -> bool {
-    let _ = repo_path;
-    if !entry.file_type().map_or(false, |ft| ft.is_file()) {
-        return false;
-    }
-    let file_name = entry.path().file_name().unwrap().to_str().unwrap();
-    // Оставляем только проверку расширения
-    config.extensions.iter().any(|ext| file_name.ends_with(ext))
+pub fn is_valid_file(_repo_path: &String, entry: &DirEntry, _config: &FtaQlConfigResolved) -> bool {
+    entry.file_type().map_or(false, |ft| ft.is_file())
 }
 
 pub fn warn_about_language(file_name: &str, use_tsx: bool) {

--- a/crates/ftaql/tests/coupling_integration_test.rs
+++ b/crates/ftaql/tests/coupling_integration_test.rs
@@ -9,9 +9,8 @@ fn coupling_analysis_on_sample_project() {
     let project_path = "tests/fixtures/sample_project";
     let snapshot_path = Path::new("fixtures").join("snapshots");
     let fta_config = FtaQlConfigResolved {
-        extensions: vec![".ts".to_string(), ".tsx".to_string()],
-        exclude_filenames: vec![],
-        exclude_directories: vec![],
+        includes: vec!["**/*.ts".to_string(), "**/*.tsx".to_string()],
+        excludes: vec![],
         score_cap: 100,
         include_comments: false,
         exclude_under: 0,
@@ -34,9 +33,8 @@ fn coupling_analysis_on_sample_project() {
 fn tsconfig_paths_resolution() {
     let project_path = "tests/fixtures/tsconfig_project";
     let fta_config = FtaQlConfigResolved {
-        extensions: vec![".ts".to_string(), ".tsx".to_string()],
-        exclude_filenames: vec![],
-        exclude_directories: vec![],
+        includes: vec!["**/*.ts".to_string(), "**/*.tsx".to_string()],
+        excludes: vec![],
         score_cap: 100,
         include_comments: false,
         exclude_under: 0,
@@ -51,9 +49,8 @@ fn tsconfig_paths_resolution() {
 fn ordered_cycle_reporting() {
     let project_path = "tests/fixtures/large_cycle_project";
     let fta_config = FtaQlConfigResolved {
-        extensions: vec![".js".to_string()],
-        exclude_filenames: vec![],
-        exclude_directories: vec![],
+        includes: vec!["**/*.js".to_string()],
+        excludes: vec![],
         score_cap: 100,
         include_comments: false,
         exclude_under: 0,

--- a/crates/ftaql/tests/filter_integration_test.rs
+++ b/crates/ftaql/tests/filter_integration_test.rs
@@ -1,0 +1,126 @@
+use ftaql::analyze_project;
+use ftaql::structs::FtaQlConfigResolved;
+use std::collections::HashSet;
+
+fn file_names(config: FtaQlConfigResolved) -> HashSet<String> {
+    let project_path = "tests/fixtures/filter_project";
+    let result = analyze_project(&project_path.to_string(), Some(config));
+    result
+        .findings
+        .into_iter()
+        .map(|f| f.file_name)
+        .collect()
+}
+
+#[test]
+fn default_excludes_filter_dts_and_dist() {
+    let config = FtaQlConfigResolved {
+        includes: vec!["**/*.ts".to_string(), "**/*.js".to_string()],
+        excludes: vec!["**/*.d.ts".to_string(), "dist/**".to_string()],
+        score_cap: 10000,
+        include_comments: false,
+        exclude_under: 0,
+    };
+
+    let names = file_names(config);
+
+    // src/index.ts and src/helper.ts should be included
+    assert!(
+        names.iter().any(|n| n.contains("src/index.ts")),
+        "expected src/index.ts in results, got: {:?}",
+        names
+    );
+    assert!(
+        names.iter().any(|n| n.contains("src/helper.ts")),
+        "expected src/helper.ts in results, got: {:?}",
+        names
+    );
+    // .d.ts should be excluded
+    assert!(
+        !names.iter().any(|n| n.contains("types.d.ts")),
+        "types.d.ts should be excluded, got: {:?}",
+        names
+    );
+    // dist/ should be excluded
+    assert!(
+        !names.iter().any(|n| n.contains("dist/")),
+        "dist/ files should be excluded, got: {:?}",
+        names
+    );
+}
+
+#[test]
+fn excludes_directory_by_glob() {
+    let config = FtaQlConfigResolved {
+        includes: vec!["**/*.ts".to_string()],
+        excludes: vec!["__tests__/**".to_string()],
+        score_cap: 10000,
+        include_comments: false,
+        exclude_under: 0,
+    };
+
+    let names = file_names(config);
+
+    // __tests__/ should be excluded
+    assert!(
+        !names.iter().any(|n| n.contains("__tests__/")),
+        "__tests__/ files should be excluded, got: {:?}",
+        names
+    );
+    // src files should still be present
+    assert!(
+        names.iter().any(|n| n.contains("src/index.ts")),
+        "expected src/index.ts in results, got: {:?}",
+        names
+    );
+}
+
+#[test]
+fn includes_limits_to_matching_files_only() {
+    // Only include .js files — no .ts files should appear
+    let config = FtaQlConfigResolved {
+        includes: vec!["**/*.js".to_string()],
+        excludes: vec![],
+        score_cap: 10000,
+        include_comments: false,
+        exclude_under: 0,
+    };
+
+    let names = file_names(config);
+
+    assert!(
+        !names.iter().any(|n| n.ends_with(".ts")),
+        "no .ts files should be included, got: {:?}",
+        names
+    );
+    assert!(
+        names.iter().any(|n| n.contains("dist/index.js")),
+        "expected dist/index.js in results, got: {:?}",
+        names
+    );
+}
+
+#[test]
+fn empty_excludes_includes_everything() {
+    let config = FtaQlConfigResolved {
+        includes: vec!["**/*.ts".to_string()],
+        excludes: vec![],
+        score_cap: 10000,
+        include_comments: false,
+        exclude_under: 0,
+    };
+
+    let names = file_names(config);
+
+    // All .ts files should be present, including .d.ts and test files
+    assert!(
+        names.iter().any(|n| n.contains("types.d.ts")),
+        "expected types.d.ts with empty excludes, got: {:?}",
+        names
+    );
+    assert!(
+        names.iter().any(|n| n.contains("index.test.ts")),
+        "expected index.test.ts with empty excludes, got: {:?}",
+        names
+    );
+}

--- a/crates/ftaql/tests/filter_integration_test.rs
+++ b/crates/ftaql/tests/filter_integration_test.rs
@@ -5,11 +5,7 @@ use std::collections::HashSet;
 fn file_names(config: FtaQlConfigResolved) -> HashSet<String> {
     let project_path = "tests/fixtures/filter_project";
     let result = analyze_project(&project_path.to_string(), Some(config));
-    result
-        .findings
-        .into_iter()
-        .map(|f| f.file_name)
-        .collect()
+    result.findings.into_iter().map(|f| f.file_name).collect()
 }
 
 #[test]

--- a/crates/ftaql/tests/fixtures/filter_project/__tests__/index.test.ts
+++ b/crates/ftaql/tests/fixtures/filter_project/__tests__/index.test.ts
@@ -1,0 +1,7 @@
+import { main } from '../src/index';
+
+describe('main', () => {
+  it('returns greeting', () => {
+    expect(main()).toBe('Hello, world!');
+  });
+});

--- a/crates/ftaql/tests/fixtures/filter_project/dist/index.js
+++ b/crates/ftaql/tests/fixtures/filter_project/dist/index.js
@@ -1,0 +1,7 @@
+function helper(name) {
+  return "Hello, " + name + "!";
+}
+function main() {
+  return helper("world");
+}
+module.exports = { main };

--- a/crates/ftaql/tests/fixtures/filter_project/src/helper.ts
+++ b/crates/ftaql/tests/fixtures/filter_project/src/helper.ts
@@ -1,0 +1,3 @@
+export function helper(name: string): string {
+  return `Hello, ${name}!`;
+}

--- a/crates/ftaql/tests/fixtures/filter_project/src/index.ts
+++ b/crates/ftaql/tests/fixtures/filter_project/src/index.ts
@@ -1,0 +1,5 @@
+import { helper } from './helper';
+
+export function main(): string {
+  return helper('world');
+}

--- a/crates/ftaql/tests/fixtures/filter_project/src/types.d.ts
+++ b/crates/ftaql/tests/fixtures/filter_project/src/types.d.ts
@@ -1,0 +1,4 @@
+export interface Config {
+  name: string;
+  value: number;
+}

--- a/crates/ftaql/tests/runtime_cycles_integration_test.rs
+++ b/crates/ftaql/tests/runtime_cycles_integration_test.rs
@@ -6,9 +6,8 @@ use insta;
 fn test_runtime_cycle_detection() {
     let project_path_str = "tests/fixtures/runtime_cycles_project";
     let fta_config = FtaQlConfigResolved {
-        extensions: vec!["ts".to_string()],
-        exclude_filenames: vec![],
-        exclude_directories: vec![],
+        includes: vec!["**/*.ts".to_string()],
+        excludes: vec![],
         score_cap: 100,
         include_comments: false,
         exclude_under: 0,

--- a/docs/configuration/en.md
+++ b/docs/configuration/en.md
@@ -12,25 +12,33 @@ If the config path is not explicitly provided and the file is missing, FtaQl fal
 
 ## Supported fields
 
-- `extensions`
-- `exclude_filenames`
-- `exclude_directories`
+- `includes` — glob patterns for files to include in analysis
+- `excludes` — glob patterns for files to exclude from analysis
 - `score_cap`
 - `include_comments`
 - `exclude_under`
 
+## Example config
+
+```json
+{
+  "includes": ["**/*.ts", "**/*.tsx"],
+  "excludes": ["**/*.d.ts", "dist/**", "__tests__/**"],
+  "score_cap": 1000
+}
+```
+
 ## Default values
 
-- `extensions`: `.js`, `.jsx`, `.ts`, `.tsx`
-- `exclude_filenames`: `.d.ts`, `.min.js`, `.bundle.js`
-- `exclude_directories`: `/dist`, `/bin`, `/build`
+- `includes`: `**/*.js`, `**/*.jsx`, `**/*.ts`, `**/*.tsx`
+- `excludes`: `**/*.d.ts`, `**/*.min.js`, `**/*.bundle.js`, `dist/**`, `bin/**`, `build/**`
 - `score_cap`: `1000`
 - `include_comments`: `false`
 - `exclude_under`: `6`
 
-## Merge behavior
+## Override behavior
 
-- `extensions`, `exclude_filenames`, and `exclude_directories` are appended to the defaults.
+- `includes` and `excludes`, when provided, **replace** the defaults entirely.
 - `score_cap`, `include_comments`, and `exclude_under` override defaults.
 - The resolved config is serialized and stored in SQLite as `analysis_runs.config_json`.
 
@@ -47,10 +55,9 @@ This affects dependency resolution and coupling analysis correctness.
 
 ## Important caveats
 
-- The default `exclude_directories` only include `/dist`, `/bin`, and `/build`.
 - During project-level analysis, FtaQl separately applies `.gitignore` and git exclude rules in addition to `ftaql.json`.
-- This means `node_modules` is often skipped automatically when it is already ignored by git rules, but it is not part of the default `exclude_directories`.
-- If a directory is not covered by `.gitignore` and you still want to skip it, add it explicitly to `exclude_directories`.
+- This means `node_modules` is often skipped automatically when it is already ignored by git rules, but it is not part of the default `excludes`.
+- If a directory is not covered by `.gitignore` and you still want to skip it, add it to `excludes`.
 - `include_comments` affects `line_count`, which also affects `file_score`.
 - `score_cap` exits the process with code `1` when a file exceeds the threshold.
 - `exclude_under` is part of the public config and is persisted into SQLite, but the current pipeline does not apply it during traversal or file filtering.

--- a/docs/configuration/ru.md
+++ b/docs/configuration/ru.md
@@ -12,25 +12,33 @@ ftaql /path/to/project --db ./ftaql.sqlite --config-path ./ftaql.json
 
 ## Поддерживаемые поля
 
-- `extensions`
-- `exclude_filenames`
-- `exclude_directories`
+- `includes` — glob-паттерны для включения файлов в анализ
+- `excludes` — glob-паттерны для исключения файлов из анализа
 - `score_cap`
 - `include_comments`
 - `exclude_under`
 
+## Пример конфига
+
+```json
+{
+  "includes": ["**/*.ts", "**/*.tsx"],
+  "excludes": ["**/*.d.ts", "dist/**", "__tests__/**"],
+  "score_cap": 1000
+}
+```
+
 ## Дефолтные значения
 
-- `extensions`: `.js`, `.jsx`, `.ts`, `.tsx`
-- `exclude_filenames`: `.d.ts`, `.min.js`, `.bundle.js`
-- `exclude_directories`: `/dist`, `/bin`, `/build`
+- `includes`: `**/*.js`, `**/*.jsx`, `**/*.ts`, `**/*.tsx`
+- `excludes`: `**/*.d.ts`, `**/*.min.js`, `**/*.bundle.js`, `dist/**`, `bin/**`, `build/**`
 - `score_cap`: `1000`
 - `include_comments`: `false`
 - `exclude_under`: `6`
 
-## Merge-поведение
+## Поведение при переопределении
 
-- `extensions`, `exclude_filenames` и `exclude_directories` дописываются к дефолтным значениям.
+- `includes` и `excludes`, если указаны, **полностью заменяют** дефолтные значения.
 - `score_cap`, `include_comments` и `exclude_under` переопределяют дефолты.
 - Resolved config сериализуется и сохраняется в SQLite как `analysis_runs.config_json`.
 
@@ -47,10 +55,9 @@ Resolver учитывает:
 
 ## Важные нюансы
 
-- Дефолтные `exclude_directories` включают только `/dist`, `/bin` и `/build`.
 - При project-level анализе FtaQl отдельно применяет правила `.gitignore` и git exclude, помимо `ftaql.json`.
-- Поэтому `node_modules` часто не попадает в обход автоматически, если уже игнорируется git-правилами, но это не часть дефолтного `exclude_directories`.
-- Если каталог не покрыт `.gitignore`, но его все равно нужно пропустить, добавьте его явно в `exclude_directories`.
+- Поэтому `node_modules` часто не попадает в обход автоматически, если уже игнорируется git-правилами, но это не часть дефолтных `excludes`.
+- Если каталог не покрыт `.gitignore`, но его все равно нужно пропустить, добавьте его в `excludes`.
 - `include_comments` влияет на `line_count`, а значит и на `file_score`.
 - `score_cap` завершает процесс с кодом `1`, если файл превысил порог.
 - `exclude_under` присутствует в публичной конфигурации и сохраняется в SQLite, но текущий pipeline его не применяет при обходе или фильтрации файлов.

--- a/packages/ftaql/README.md
+++ b/packages/ftaql/README.md
@@ -230,14 +230,13 @@ By default, the native CLI looks for `ftaql.json` in the analyzed project root. 
 
 The `ftaql.json` file controls analysis behavior such as:
 
-- `extensions`
-- `exclude_filenames`
-- `exclude_directories`
+- `includes` — glob patterns for files to include
+- `excludes` — glob patterns for files to exclude
 - `score_cap`
 - `include_comments`
 - `exclude_under`
 
-During project-level analysis, FtaQl also respects `.gitignore`. That means `node_modules` is usually skipped automatically when it is already ignored by git rules. If a directory is not covered by `.gitignore`, add it to `exclude_directories`. See [`docs/configuration/en.md`](https://github.com/pikulev/ftaql/blob/main/docs/configuration/en.md) for details.
+During project-level analysis, FtaQl also respects `.gitignore`. That means `node_modules` is usually skipped automatically when it is already ignored by git rules. If a directory is not covered by `.gitignore`, add it to `excludes`. See [`docs/configuration/en.md`](https://github.com/pikulev/ftaql/blob/main/docs/configuration/en.md) for details.
 
 FtaQl also auto-detects `tsconfig.json` and `jsconfig.json` files when resolving imports. It supports:
 


### PR DESCRIPTION
## Summary

- **BREAKING CHANGE**: Replace `extensions`, `exclude_filenames`, `exclude_directories` config fields with glob-based `includes` and `excludes`
- User-provided values now **replace** defaults (not append)
- Fixes override pattern construction bugs (missing catch-all, leading `/` in directories, substring matching for filenames)
- Add e2e tests for include/exclude filtering

## New config format

```json
{
  "includes": ["**/*.ts", "**/*.tsx"],
  "excludes": ["**/*.d.ts", "dist/**", "__tests__/**"]
}
```

## Defaults

- `includes`: `**/*.js`, `**/*.jsx`, `**/*.ts`, `**/*.tsx`
- `excludes`: `**/*.d.ts`, `**/*.min.js`, `**/*.bundle.js`, `dist/**`, `bin/**`, `build/**`

## Test plan

- [x] All 54 tests pass (`cargo test --all`)
- [x] 4 new e2e tests verify include/exclude filtering
- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all --all-targets` passes

Closes #22
Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)